### PR TITLE
Compilation warning fixes

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -337,7 +337,7 @@ BufferRange ZepBuffer::InnerWordMotion(BufferLocation start, uint32_t searchType
     return r;
 }
 
-BufferLocation ZepBuffer::FindOnLineMotion(BufferLocation start, utf8* pCh, SearchDirection dir) const
+BufferLocation ZepBuffer::FindOnLineMotion(BufferLocation start, const utf8* pCh, SearchDirection dir) const
 {
     auto entry = start;
     auto IsMatch = [pCh](const char ch)

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -110,7 +110,7 @@ public:
     bool SkipOne(fnMatch IsToken, BufferLocation& start, SearchDirection dir) const;
     bool SkipNot(fnMatch IsToken, BufferLocation& start, SearchDirection dir) const;
 
-    BufferLocation FindOnLineMotion(BufferLocation start, utf8* pCh, SearchDirection dir) const;
+    BufferLocation FindOnLineMotion(BufferLocation start, const utf8* pCh, SearchDirection dir) const;
     BufferLocation WordMotion(BufferLocation start, uint32_t searchType, SearchDirection dir) const;
     BufferLocation EndWordMotion(BufferLocation start, uint32_t searchType, SearchDirection dir) const;
     BufferLocation ChangeWordMotion(BufferLocation start, uint32_t searchType, SearchDirection dir) const;

--- a/src/commands.h
+++ b/src/commands.h
@@ -50,8 +50,8 @@ public:
 protected:
     ZepBuffer& m_buffer;
     uint32_t m_flags = 0;
-    BufferLocation m_cursorAfter = -1;
     BufferLocation m_cursorBefore = -1;
+    BufferLocation m_cursorAfter = -1;
 };
 
 class ZepCommand_DeleteRange : public ZepCommand

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -37,8 +37,8 @@ ZepComponent::~ZepComponent()
 }
 
 ZepEditor::ZepEditor(IZepDisplay* pDisplay, const fs::path& root, uint32_t flags)
-    : m_flags(flags)
-    , m_pDisplay(pDisplay)
+    : m_pDisplay(pDisplay)
+    , m_flags(flags)
     , m_rootPath(root)
 {
     LoadConfig(root / "zep.cfg");
@@ -632,12 +632,12 @@ void ZepEditor::Display()
             // Show active buffer in tab as tab name
             auto& buffer = window->GetActiveWindow()->GetBuffer();
             auto tabColor = (window == GetActiveTabWindow()) ? GetTheme().GetColor(ThemeColor::TabActive) : GetTheme().GetColor(ThemeColor::TabInactive);
-            auto tabLength = m_pDisplay->GetTextSize((utf8*)buffer.GetName().c_str()).x + textBorder * 2;
+            auto tabLength = m_pDisplay->GetTextSize((const utf8*)buffer.GetName().c_str()).x + textBorder * 2;
 
             NRectf tabRect(currentTab, currentTab + NVec2f(tabLength, m_tabRegion->rect.Height()));
             m_pDisplay->DrawRectFilled(tabRect, tabColor);
 
-            m_pDisplay->DrawChars(currentTab + NVec2f(textBorder, textBorder), NVec4f(1.0f), (utf8*)buffer.GetName().c_str());
+            m_pDisplay->DrawChars(currentTab + NVec2f(textBorder, textBorder), NVec4f(1.0f), (const utf8*)buffer.GetName().c_str());
 
             currentTab.x += tabLength + textBorder;
             m_tabRects[window] = tabRect;

--- a/src/gap_buffer.h
+++ b/src/gap_buffer.h
@@ -83,9 +83,9 @@ public:
 
         GapBuffer<T>& buffer;
 
-        iterator(GapBuffer<T>& buff, size_t ptr, bool skip = true) : buffer(buff), p(ptr), skipGap(skip)  { };
-        iterator(const iterator& rhs) : buffer(rhs.buffer), p(rhs.p), skipGap(rhs.skipGap) { }
-        ~iterator() {};
+        iterator(GapBuffer<T>& buff, size_t ptr, bool skip = true) : skipGap(skip), p(ptr), buffer(buff) { }
+        iterator(const iterator& rhs) : skipGap(rhs.skipGap), p(rhs.p), buffer(rhs.buffer) { }
+        ~iterator() { }
 
         iterator& operator=(const iterator& rhs) { p = rhs.p; return *this; }
         
@@ -127,10 +127,10 @@ public:
         size_t p = 0;
         const GapBuffer<T>& buffer;
 
-        const_iterator(const GapBuffer<T>& buff, size_t ptr, bool skip = true) : buffer(buff), p(ptr), skipGap(skip)  { };
-        const_iterator(const iterator& rhs) : buffer(rhs.buffer), p(rhs.p), skipGap(rhs.skipGap) { }
-        const_iterator(const const_iterator& rhs) : buffer(rhs.buffer), p(rhs.p), skipGap(rhs.skipGap) { }
-        ~const_iterator() {};
+        const_iterator(const GapBuffer<T>& buff, size_t ptr, bool skip = true) : skipGap(skip), p(ptr), buffer(buff) { }
+        const_iterator(const iterator& rhs) : skipGap(rhs.skipGap), p(rhs.p), buffer(rhs.buffer) { }
+        const_iterator(const const_iterator& rhs) : skipGap(rhs.skipGap), p(rhs.p), buffer(rhs.buffer) { }
+        ~const_iterator() { }
 
         const_iterator& operator=(const const_iterator& rhs) { p = rhs.p; return *this; }
         bool operator==(const const_iterator& rhs) const { return (p == rhs.p); }

--- a/src/imgui/console_imgui.h
+++ b/src/imgui/console_imgui.h
@@ -69,7 +69,6 @@ struct ZepConsole : Zep::IZepComponent
             return;
         }
 
-        auto pos = ImGui::GetWindowPos();
         auto size = ImGui::GetWindowContentRegionMax();
         auto cursor = ImGui::GetCursorScreenPos();
         

--- a/src/imgui/display_imgui.cpp
+++ b/src/imgui/display_imgui.cpp
@@ -20,7 +20,7 @@ NVec2f ZepDisplay_ImGui::GetTextSize(const utf8* pBegin, const utf8* pEnd) const
     if (text_size.x == 0.0)
     {
         // Make invalid characters a default fixed_size
-        return GetTextSize((utf8*)"A");
+        return GetTextSize((const utf8*)"A");
     }
 
     return toNVec2f(text_size);

--- a/src/mcommon/file/archive.cpp
+++ b/src/mcommon/file/archive.cpp
@@ -644,7 +644,7 @@ std::string archive_to_file_text(Archive& ar)
                 {
                     if (i == 0)
                     {
-                        for (size_t i = itrKeys->first.ToString().size(); i < 30; i++)
+                        for (size_t j = itrKeys->first.ToString().size(); j < 30; j++)
                         {
                             str << " ";
                         }

--- a/src/mcommon/string/stringutils.cpp
+++ b/src/mcommon/string/stringutils.cpp
@@ -71,7 +71,7 @@ uint32_t murmur_hash(const void* key, int len, uint32_t seed)
 #ifdef PLATFORM_BIG_ENDIAN
         unsigned int k = (data[0]) + (data[1] << 8) + (data[2] << 16) + (data[3] << 24);
 #else
-        unsigned int k = *(unsigned int*)data;
+        unsigned int k = (data[3]) + (data[2] << 8) + (data[1] << 16) + (data[0] << 24);
 #endif
 
         k *= m;

--- a/src/mode_vim.h
+++ b/src/mode_vim.h
@@ -114,7 +114,7 @@ public:
     {
         return m_lastCommand;
     }
-    const int GetLastCount() const
+    int GetLastCount() const
     {
         return m_lastCount;
     }

--- a/src/syntax.cpp
+++ b/src/syntax.cpp
@@ -18,9 +18,9 @@ ZepSyntax::ZepSyntax(
     uint32_t flags)
     : ZepComponent(buffer.GetEditor())
     , m_buffer(buffer)
-    , m_stop(false)
     , m_keywords(keywords)
     , m_identifiers(identifiers)
+    , m_stop(false)
     , m_flags(flags)
 {
     m_syntax.resize(m_buffer.GetText().size());

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -2,6 +2,12 @@
 
 #include "buffer.h"
 
+#include <set>
+#include <vector>
+#include <future>
+#include <atomic>
+#include <memory>
+
 namespace Zep
 {
 
@@ -72,8 +78,8 @@ class ZepSyntaxAdorn : public ZepComponent
 public:
     ZepSyntaxAdorn(ZepSyntax& syntax, ZepBuffer& buffer)
         : ZepComponent(syntax.GetEditor())
-        , m_syntax(syntax)
         , m_buffer(buffer)
+        , m_syntax(syntax)
     {
     }
 

--- a/src/theme.h
+++ b/src/theme.h
@@ -49,6 +49,8 @@ class ZepTheme
 {
 public:
     ZepTheme();
+    virtual ~ZepTheme() {}
+
     virtual NVec4f GetColor(ThemeColor themeColor) const;
     virtual NVec4f GetComplement(const NVec4f& col) const;
     virtual NVec4f GetUniqueColor(uint32_t id) const;

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -26,8 +26,8 @@ NVec2f DefaultCharSize;
 
 ZepWindow::ZepWindow(ZepTabWindow& window, ZepBuffer* buffer)
     : ZepComponent(window.GetEditor())
-    , m_pBuffer(buffer)
     , m_tabWindow(window)
+    , m_pBuffer(buffer)
 {
     m_bufferRegion = std::make_shared<Region>();
     m_numberRegion = std::make_shared<Region>();
@@ -742,7 +742,7 @@ void ZepWindow::BuildCharCache()
     m_charCacheDirty = false;
    
     const char chA = 'A';
-    DefaultCharSize = GetEditor().GetDisplay().GetTextSize((utf8*)&chA, (utf8*)&chA + 1);
+    DefaultCharSize = GetEditor().GetDisplay().GetTextSize((const utf8*)&chA, (const utf8*)&chA + 1);
     for (int i = 0; i < 256; i++)
     {
         utf8 ch = (utf8)i;
@@ -937,9 +937,8 @@ NVec2i ZepWindow::BufferToDisplay(const BufferLocation& loc)
 
 } // namespace Zep
 
-/*
+#if 0
     // Ensure we can see the cursor
-    /*
     NVec2i cursor(0, 0);
     cursor.x = m_pBuffer->GetBufferColumn(m_bufferCursor);
     cursor.y = m_pBuffer->GetBufferLine(m_bufferCursor) - m_pBuffer->GetBufferLine(m_dvisibleLineRange.x);
@@ -959,4 +958,5 @@ NVec2i ZepWindow::BufferToDisplay(const BufferLocation& loc)
 
     // Clamp
     m_nvisibleLineRange.x = std::max(0l, (long)m_nvisibleLineRange.x);
-*/
+#endif
+


### PR DESCRIPTION
# Description

Various fixes for compilation warnings reported by GCC, including one that caused crashes on ARM CPUs:
  - murmur_hash: fix unaligned access
  - missing includes for various C++ classes
  - wrong const qualifiers when casting char arrays
  - reordered class member initialisations
  - missing virtual destructor on class with virtual methods
  - variables shadowing other variables in the outer scope
  - /* inside comment