### PR TITLE
Make buffer ThreadPool object creation safer.

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -54,6 +54,17 @@ ZepBuffer::ZepBuffer(ZepEditor& editor, const std::string& strName)
     : ZepComponent(editor)
     , m_strName(strName)
 {
+    if (!(editor.GetFlags() & ZepEditorFlags::DisableThreads))
+    {
+        try
+        {
+            m_spThreadPool = std::make_shared<ThreadPool>();
+        }
+        catch (std::invalid_argument &)
+        {
+            // Threads are not supported on this platform; ignore
+        }
+    }
     SetText("");
 }
 

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -96,9 +96,9 @@ public:
     BufferLocation ClampToVisibleLine(BufferLocation in) const;
     long GetBufferColumn(BufferLocation location) const;
 
-    ThreadPool& GetThreadPool()
+    std::shared_ptr<ThreadPool> GetThreadPool()
     {
-        return m_threadPool;
+        return m_spThreadPool;
     }
 
     using fnMatch = std::function<bool(const char)>;
@@ -201,7 +201,7 @@ private:
     bool m_dirty = false;         // Is the text modified?
     GapBuffer<utf8> m_gapBuffer;  // Storage for the text - a gap buffer for efficiency
     std::vector<long> m_lineEnds; // End of each line
-    ThreadPool m_threadPool;
+    std::shared_ptr<ThreadPool> m_spThreadPool;
     uint32_t m_fileFlags = FileFlags::NotYetSaved | FileFlags::FirstInit;
     std::shared_ptr<ZepSyntax> m_spSyntax;
     std::string m_strName;

--- a/src/syntax.cpp
+++ b/src/syntax.cpp
@@ -93,13 +93,13 @@ void ZepSyntax::QueueUpdateSyntax(BufferLocation startLocation, BufferLocation e
     m_targetChar = std::min(long(m_targetChar), long(m_buffer.GetText().size() - 1));
 
     // Have the thread update the syntax in the new region
-    if (GetEditor().GetFlags() & ZepEditorFlags::DisableThreads)
+    if (!m_buffer.GetThreadPool())
     {
         UpdateSyntax();
     }
     else
     {
-        m_syntaxResult = m_buffer.GetThreadPool().enqueue([=]() {
+        m_syntaxResult = m_buffer.GetThreadPool()->enqueue([=]() {
             UpdateSyntax();
         });
     }


### PR DESCRIPTION
# Description

Only construct the object when threads are actually enabled and catch invalid
argument exceptions (thrown if std::thread::hardware_concurrency is zero, for
instance with emscripten).

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

**Test Configuration**:
* OS: Debian GNU/Linux unstable

# Checklist:

- [ ] My code has been formatted with the clang format file
- [X] New and existing unit tests pass locally with my changes
- [X] Qt and ImGui demo projects function correctly
