### PR TITLE
Vim mode: fix x command behaviour and add proper unit tests.

### DIFF
--- a/src/mode_vim.cpp
+++ b/src/mode_vim.cpp
@@ -944,8 +944,10 @@ bool ZepMode_Vim::GetCommand(CommandContext& context)
             if (context.command != "x" || std::isgraph(context.buffer.GetText()[loc]) || std::isblank(context.buffer.GetText()[loc]))
             {
                 context.beginRange = loc;
-                context.endRange = context.buffer.LocationFromOffsetByChars(loc, 1);
+                context.endRange = std::min(context.buffer.GetLinePos(loc, LineLocation::LineCRBegin),
+                                            context.buffer.LocationFromOffsetByChars(loc, context.count));
                 context.op = CommandOperation::Delete;
+                context.commandResult.flags |= CommandResultFlags::HandledCount;
             }
             else
             {

--- a/src/tests/mode_vim.test.cpp
+++ b/src/tests/mode_vim.test.cpp
@@ -291,6 +291,11 @@ COMMAND_TEST(delete_dd, "one three", "dd", "")
 COMMAND_TEST(delete_D, "one three", "lD", "o")
 COMMAND_TEST(undo_redo, "one two three", "vllydur", "one two three")
 
+COMMAND_TEST(delete_to_eol, "hello\nworld", "lll10x", "hel\nworld");
+COMMAND_TEST(delete_x_paste, "hello", "lxp", "hlelo");
+COMMAND_TEST(delete_3x, "hello", "3x", "lo");
+COMMAND_TEST(delete_3x_paste, "hello", "l3xp", "hoell");
+
 COMMAND_TEST(delete_d_visual, "one three", "lvld", "o three")
 
 COMMAND_TEST(change_cc, "one two", "cchellojk", "hello")


### PR DESCRIPTION
# Description

The “x” command must handle the prefixed count immediately, otherwise the
paste buffer will only contain the last deleted character.

For instance, if the buffer contained `abcd` and the user typed `2xp`, the buffer
would contain `cbd`. The expected result in Vim is `cabd`.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* OS: Debian GNU/Linux unstable

# Checklist:

- [ ] My code has been formatted with the clang format file
- [X] New and existing unit tests pass locally with my changes
- [X] Qt and ImGui demo projects function correctly
