### PR TITLE
Fix clang warnings about unused variables by casting to void.

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -154,10 +154,10 @@ BufferLocation ZepBuffer::LocationFromOffset(long offset) const
 
 BufferLocation ZepBuffer::Search(const std::string& str, BufferLocation start, SearchDirection dir, BufferLocation end) const
 {
-    end;
-    dir;
-    start;
-    str;
+    (void)end;
+    (void)dir;
+    (void)start;
+    (void)str;
     return BufferLocation{0};
 }
 

--- a/src/display.h
+++ b/src/display.h
@@ -49,27 +49,27 @@ public:
     }
     virtual void DrawLine(const NVec2f& start, const NVec2f& end, const NVec4f& color = NVec4f(1.0f), float width = 1.0f) const override
     {
-        start;
-        end;
-        color;
-        width;
+        (void)start;
+        (void)end;
+        (void)color;
+        (void)width;
     };
     virtual void DrawChars(const NVec2f& pos, const NVec4f& col, const utf8* text_begin, const utf8* text_end = nullptr) const override
     {
-        pos;
-        col;
-        text_begin;
-        text_end;
+        (void)pos;
+        (void)col;
+        (void)text_begin;
+        (void)text_end;
     }
     virtual void DrawRectFilled(const NRectf& a, const NVec4f& col = NVec4f(1.0f)) const override
     {
-        a;
-        col;
+        (void)a;
+        (void)col;
 
     };
     virtual void SetClipRect(const NRectf& rc) override
     {
-        rc;
+        (void)rc;
     }
 };
 

--- a/src/mcommon/file/file.cpp
+++ b/src/mcommon/file/file.cpp
@@ -30,8 +30,8 @@ public:
 
     void handleFileAction(FW::WatchID watchid, const FW::String& dir, const FW::String& filename, FW::Action action)
     {
-        dir;
-        watchid;
+        (void)dir;
+        (void)watchid;
 
         if (action == FW::Action::Modified)
         {
@@ -65,8 +65,8 @@ void file_update_dir_watch()
 #else
 void file_init_dir_watch(const fs::path& dir, fileCB callback)
 {
-    dir;
-    callback;
+    (void)dir;
+    (void)callback;
 }
 
 void file_destroy_dir_watch()


### PR DESCRIPTION
The recommended way to mark a variable as deliberately unused seems to be casting it to `void`. There is also the `[[maybe_unused]]` attribute but it’s C++17 only…