### PR TITLE
Ignore backspace when at first line, first column

### DIFF
--- a/src/mode_standard.cpp
+++ b/src/mode_standard.cpp
@@ -302,6 +302,10 @@ void ZepMode_Standard::AddKeyPress(uint32_t key, uint32_t modifierKeys)
         }
         else
         {
+            if (startOffset == 0)
+            {
+                return;
+            }
             endOffset = startOffset;
             startOffset = buffer.LocationFromOffsetByChars(startOffset, -1);
         }

--- a/src/mode_vim.cpp
+++ b/src/mode_vim.cpp
@@ -865,6 +865,10 @@ bool ZepMode_Vim::GetCommand(CommandContext& context)
         // Insert-mode context.command
         if (context.mode == EditorMode::Insert)
         {
+            if (loc == 0)
+            {
+                return true;
+            }
             // In insert mode, we are 'on' the character after the one we want to delete
             context.beginRange = context.buffer.LocationFromOffsetByChars(loc, -1);
             context.endRange = context.buffer.LocationFromOffsetByChars(loc, 0);


### PR DESCRIPTION
# Description

When pressing backspace at line 1, column 1, the application crashes. Reproduced in ImGui demo (Qt untested as I dont have 50gb to spare for Qt).

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* OS: Windows 10 1803, MSVC 19.16.27025.1

# Checklist:

- [ ] My code has been formatted with the clang format file
- [X] New and existing unit tests pass locally with my changes
- [Partially] Qt and ImGui demo projects function correctly (see remarks above about Qt)
