### PR TITLE
Fix the ImGui build.

### DIFF
--- a/include/zep/imgui/console_imgui.h
+++ b/include/zep/imgui/console_imgui.h
@@ -33,7 +33,7 @@ struct ZepConsole : Zep::IZepComponent
     {
         zepEditor.RegisterCallback(this);
         auto pBuffer = zepEditor.GetEmptyBuffer("Log");
-        pBuffer->SetFlags(Zep::FileFlags::ReadOnly);
+        pBuffer->SetFileFlags(Zep::FileFlags::ReadOnly);
     }
 
     void AddLog(const char* fmt, ...) IM_FMTARGS(2)
@@ -86,7 +86,8 @@ struct ZepConsole : Zep::IZepComponent
         {
             // TODO: This looks like a hack: investigate why it is needed for the drop down console.
             // I think the intention here is to ensure the mode is reset while it is dropping down. I don't recall.
-            zepEditor.GetActiveTabWindow()->GetActiveWindow()->GetBuffer().GetMode()->Begin();
+            auto *pWindow = zepEditor.GetActiveTabWindow()->GetActiveWindow();
+            pWindow->GetBuffer().GetMode()->Begin(pWindow);
         }
 
         ImGui::End();


### PR DESCRIPTION
# Description

 - `ZepBuffer::SetFlags` is now `ZepBuffer::SetFileFlags` (changed in 47fa8e2165b4425829eb28a089ed6bd29ad7e6c2)
 - `ZepMode::Begin` requires a window argument (introduced in 1364206ce38ff0c9a1264867f50ff926c3b26ae8).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
